### PR TITLE
Ask Git to use LF Line endings through a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This pull request adds a .gitattributes file which configures Git to use LF line endings. This change is necessary because Git for Windows will convert all of the line endings to CRLF by default. As a result, the Dockerfile provided within oatpp-starter will not work out of the box on a Windows Development Machine until you swap the line endings in your code editor. This may frustrate people new to the oatpp framework.

If the line endings are set to CRLF in the Dockerfile you will get a vague error message stating that `/service/utility/install-oatpp-modules.sh` was not found. This is because path line endings are not set correctly and are not understood by Docker.